### PR TITLE
🔧 chore(deps): bump mantine and type dependencies to latest patch versions

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,6 @@
     "@gfazioli/mantine-marquee": "workspace:*",
     "@mantine/code-highlight": "8.3.8",
     "@mantine/core": "8.3.8",
-    "@mantine/dates": "^8.3.8",
     "@mantine/hooks": "8.3.8",
     "@mantinex/demo": "^2.0.0",
     "@mantinex/dev-icons": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,35 @@
 {
+  "name": "m-90d2bb8",
+  "version": "0.1.1",
   "description": "This package.json is not published to npm, modify the file in package/package.json",
+  "packageManager": "yarn@4.11.0",
+  "repository": "mantinedev/extension-template.git",
+  "workspaces": [
+    "docs",
+    "package"
+  ],
+  "scripts": {
+    "build": "rollup -c rollup.config.mjs && tsx scripts/generate-dts && tsx scripts/prepare-css",
+    "clean": "rimraf package/dist",
+    "dev": "cd docs && npm run dev",
+    "docgen": "tsx scripts/docgen",
+    "docs:build": "npm run docgen && cd docs && npm run build",
+    "docs:deploy": "npm run docs:build && tsx scripts/nojekyll && gh-pages -d docs/out -t",
+    "eslint": "eslint --cache .",
+    "jest": "jest",
+    "lint": "npm run eslint && npm run stylelint",
+    "prettier:check": "prettier --check \"**/*.{ts,tsx,css,mdx}\"",
+    "prettier:write": "prettier --write \"**/*.{ts,tsx,css,mdx}\"",
+    "release:major": "tsx scripts/release major && npm run docs:deploy",
+    "release:minor": "tsx scripts/release minor && npm run docs:deploy",
+    "release:patch": "tsx scripts/release patch && npm run docs:deploy",
+    "storybook": "storybook dev -p 8271",
+    "stylelint": "stylelint '**/*.css' --cache",
+    "syncpack": "syncpack list-mismatches",
+    "syncpack:format": "syncpack format",
+    "test": "npm run syncpack && npm run prettier:check && npm run typecheck && npm run lint && npm run jest",
+    "typecheck": "tsc --noEmit && cd docs && npm run typecheck"
+  },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
     "@ianvs/prettier-plugin-sort-imports": "^4.7.0",
@@ -67,35 +97,5 @@
     "vite": "^6.4.1",
     "yargs": "^17.7.2",
     "zx": "^8.8.5"
-  },
-  "name": "m-90d2bb8",
-  "packageManager": "yarn@4.11.0",
-  "repository": "mantinedev/extension-template.git",
-  "scripts": {
-    "build": "rollup -c rollup.config.mjs && tsx scripts/generate-dts && tsx scripts/prepare-css",
-    "clean": "rimraf package/dist",
-    "dev": "cd docs && npm run dev",
-    "docgen": "tsx scripts/docgen",
-    "docs:build": "npm run docgen && cd docs && npm run build",
-    "docs:deploy": "npm run docs:build && tsx scripts/nojekyll && gh-pages -d docs/out -t",
-    "eslint": "eslint --cache .",
-    "jest": "jest",
-    "lint": "npm run eslint && npm run stylelint",
-    "prettier:check": "prettier --check \"**/*.{ts,tsx,css,mdx}\"",
-    "prettier:write": "prettier --write \"**/*.{ts,tsx,css,mdx}\"",
-    "release:major": "tsx scripts/release major && npm run docs:deploy",
-    "release:minor": "tsx scripts/release minor && npm run docs:deploy",
-    "release:patch": "tsx scripts/release patch && npm run docs:deploy",
-    "storybook": "storybook dev -p 8271",
-    "stylelint": "stylelint '**/*.css' --cache",
-    "syncpack": "syncpack list-mismatches",
-    "syncpack:format": "syncpack format",
-    "test": "npm run syncpack && npm run prettier:check && npm run typecheck && npm run lint && npm run jest",
-    "typecheck": "tsc --noEmit && cd docs && npm run typecheck"
-  },
-  "version": "0.1.1",
-  "workspaces": [
-    "docs",
-    "package"
-  ]
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2305,21 +2305,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mantine/dates@npm:^8.3.8":
-  version: 8.3.8
-  resolution: "@mantine/dates@npm:8.3.8"
-  dependencies:
-    clsx: "npm:^2.1.1"
-  peerDependencies:
-    "@mantine/core": 8.3.8
-    "@mantine/hooks": 8.3.8
-    dayjs: ">=1.0.0"
-    react: ^18.x || ^19.x
-    react-dom: ^18.x || ^19.x
-  checksum: 10c0/af71adcfec089d2062b4eac0086deba54f62511747d33ac593b6eb1505338c4e8a20d1c163da8681f0860595752e29460643e122e6b7e15ad9967ee7da5335d1
-  languageName: node
-  linkType: hard
-
 "@mantine/hooks@npm:8.3.8":
   version: 8.3.8
   resolution: "@mantine/hooks@npm:8.3.8"
@@ -7276,7 +7261,6 @@ __metadata:
     "@gfazioli/mantine-marquee": "workspace:*"
     "@mantine/code-highlight": "npm:8.3.8"
     "@mantine/core": "npm:8.3.8"
-    "@mantine/dates": "npm:^8.3.8"
     "@mantine/hooks": "npm:8.3.8"
     "@mantinex/demo": "npm:^2.0.0"
     "@mantinex/dev-icons": "npm:^2.0.0"


### PR DESCRIPTION
- Update Mantine core, hooks, code-highlight, dates to 8.3.8
- Update @types/react to 19.2.5
- Update @types/yargs to 17.0.35
- Update @eslint/js to 9.39.1
